### PR TITLE
fix: typo in folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ How to run the app?
 How to make a build of React code?
 
 ```
- $ cd liteman-rc
+ $ cd litepy-rc
  $ yarn run build
 ```
 


### PR DESCRIPTION
I didn't see any `liteman-rc` folder in this project, so I believe this was a typo of  `litepy-rc`  folder instead.